### PR TITLE
Feature/web/rest api 동작방식 개선 , issue 조건 필터링 기능 추가

### DIFF
--- a/Back-End/controller/comment/index.js
+++ b/Back-End/controller/comment/index.js
@@ -1,12 +1,17 @@
 require('dotenv').config();
-const { comment } = require('../../models/sequelize');
+const { comment, model } = require('../../models/sequelize');
 
 function commentController() {}
 
 commentController.get = async (req, res) => {
     const { issueId } = req.params;
+    //console.log(issueId);
+
+    //console.log(query);
     try {
-        const result = await comment.get({ issueId: issueId });
+        const result = issueId
+            ? await comment.get(issueId)
+            : await comment.findAll();
         res.status(200).json({ result: result });
     } catch (e) {
         console.error(e);

--- a/Back-End/controller/label/index.js
+++ b/Back-End/controller/label/index.js
@@ -4,8 +4,10 @@ const { label } = require('../../models/sequelize');
 function labelController() {}
 
 labelController.get = async (req, res) => {
+    const { id } = req.params;
+
     try {
-        const result = await label.get();
+        const result = await label.get(id);
         res.status(200).json({ result: result });
     } catch (e) {
         res.status(400).json({ result: false });

--- a/Back-End/controller/milestone/index.js
+++ b/Back-End/controller/milestone/index.js
@@ -4,7 +4,10 @@ const { milestone } = require('../../models/sequelize');
 function milestoneController() {}
 
 milestoneController.get = async (req, res) => {
-    const result = await milestone.findAll();
+    const { id } = req.params;
+    const query = {};
+    if (id) query.where = { id };
+    const result = await milestone.findAll(query);
     res.status(200).json({ result: result });
 };
 

--- a/Back-End/models/issue.js
+++ b/Back-End/models/issue.js
@@ -1,5 +1,3 @@
-milestoneconst { query } = require('express');
-
 module.exports = (sequelize, Datatypes) => {
     const issue = sequelize.define(
         'issue',

--- a/Back-End/models/issue.js
+++ b/Back-End/models/issue.js
@@ -1,3 +1,5 @@
+milestoneconst { query } = require('express');
+
 module.exports = (sequelize, Datatypes) => {
     const issue = sequelize.define(
         'issue',
@@ -60,8 +62,8 @@ module.exports = (sequelize, Datatypes) => {
         });
     };
 
-    issue.get = async ({ model }) => {
-        const result = await issue.findAll({
+    issue.get = async ({ model, id, filterQuery }) => {
+        const query = {
             include: [
                 {
                     model: model.user,
@@ -69,7 +71,7 @@ module.exports = (sequelize, Datatypes) => {
                 },
                 {
                     model: model.milestone,
-                    attributes: ['title'],
+                    // attributes: ['title'],
                 },
                 {
                     model: model.has_label,
@@ -93,9 +95,16 @@ module.exports = (sequelize, Datatypes) => {
                         },
                     ],
                 },
+                {
+                    model: model.comment,
+                    attributes: ['user_id'],
+                },
             ],
+            where: filterQuery,
             attributes: ['id', 'title', 'status', 'contents', 'created'],
-        });
+        };
+        if (id) query.where = { id };
+        const result = await issue.findAll(query);
         return result;
     };
 

--- a/Back-End/models/label.js
+++ b/Back-End/models/label.js
@@ -27,11 +27,12 @@ module.exports = (sequelize, Datatypes) => {
             onDelete: 'cascade',
         });
     };
-    label.get = async () => {
-        const result = await label.findAll({
+    label.get = async (id) => {
+        const query = {
             raw: true,
-        });
-        return result;
+        };
+        if (id) query.where = { id };
+        return await label.findAll(query);
     };
 
     label.insert = async ({ title, contents, color }) => {

--- a/Back-End/routes/comment/index.js
+++ b/Back-End/routes/comment/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const commentController = require('../../controller/comment');
 
-router.get('/get/:issueId', commentController.get);
-router.post('/insert', commentController.insert);
-router.put('/update', commentController.update);
-router.delete('/delete', commentController.delete);
+router.get('/:issueId?', commentController.get);
+router.post('/', commentController.insert);
+router.put('/', commentController.update);
+router.delete('/', commentController.delete);
 
 module.exports = router;

--- a/Back-End/routes/has_assignee/index.js
+++ b/Back-End/routes/has_assignee/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const assigneeController = require('../../controller/assignee');
 
-router.get('/get/:issueId', assigneeController.get);
-router.post('/insert', assigneeController.insert);
-router.put('/update', assigneeController.update);
-router.delete('/delete', assigneeController.delete);
+router.get('/:issueId', assigneeController.get);
+router.post('/', assigneeController.insert);
+router.put('/', assigneeController.update);
+router.delete('/', assigneeController.delete);
 
 module.exports = router;

--- a/Back-End/routes/has_label/index.js
+++ b/Back-End/routes/has_label/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const hasLabelController = require('../../controller/has_label');
 
-router.get('/get/:issueId', hasLabelController.get);
-router.post('/insert', hasLabelController.insert);
-router.put('/update', hasLabelController.update);
-router.delete('/delete', hasLabelController.delete);
+router.get('/:issueId?', hasLabelController.get);
+router.post('/', hasLabelController.insert);
+router.put('/', hasLabelController.update);
+router.delete('/', hasLabelController.delete);
 
 module.exports = router;

--- a/Back-End/routes/issue/index.js
+++ b/Back-End/routes/issue/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const issueController = require('../../controller/issue');
 
-router.get('/get', issueController.get);
-router.post('/insert', issueController.insert);
-router.put('/update', issueController.update);
-router.delete('/delete', issueController.delete);
+router.get('/:issueId?', issueController.get);
+router.post('/', issueController.insert);
+router.put('/', issueController.update);
+router.delete('/', issueController.delete);
 
 module.exports = router;

--- a/Back-End/routes/label/index.js
+++ b/Back-End/routes/label/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const labelController = require('../../controller/label');
 
-router.get('/get', labelController.get);
-router.post('/insert', labelController.insert);
-router.put('/update', labelController.update);
-router.delete('/delete', labelController.delete);
+router.get('/:id?', labelController.get);
+router.post('/', labelController.insert);
+router.put('/', labelController.update);
+router.delete('/', labelController.delete);
 
 module.exports = router;

--- a/Back-End/routes/milestone/index.js
+++ b/Back-End/routes/milestone/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = express.Router();
 const milestoneController = require('../../controller/milestone');
 
-router.get('/get', milestoneController.get);
-router.post('/insert', milestoneController.insert);
-router.put('/update', milestoneController.update);
-router.delete('/delete', milestoneController.delete);
+router.get('/', milestoneController.get);
+router.post('/', milestoneController.insert);
+router.put('/', milestoneController.update);
+router.delete('/', milestoneController.delete);
 
 module.exports = router;


### PR DESCRIPTION
## 공통사항
api 호출시 주소는 동일하지만 method를 GET/POST/PUT/DELETE에 맞게 CRUD 호출되도록 개선  

## issue 조건 필터링 추가 
/issue GET 호출시 /issue?status=1&mention=1 과 같이 query string을 붙여서 보내면 조건 필터링이 적용된 issue 목록 반환

가능한 query 
status : 열린 issue/닫힌 issue
mention : issue에 comment 남긴 user id  (내가 댓글남긴 issue 검색할때 사용) 
author : issue 작성자 user id
labels : issue의 label id
- label 여러개 선택시 :  /issue?labels=1&labels=2&labels=3  

milestone : 해당 issue가 속한 milestone id
asignee :  현재 issue 담당자 user id